### PR TITLE
Option to select a region on AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Requirements:
 
     mail = Mail(aws_access_key_id="####",
                  aws_secret_access_key="####",
+                 region="us-east-1",
                  sender="me@myemail.com",
                  reply_to="me@email.com",
                  template="./email-templates")
@@ -157,6 +158,8 @@ These are the available options:
 
 **SES_AWS_SECRET_KEY**: Your AWS secred key
 
+**SES_REGION**: AWS region of the SES
+
 **SES_SENDER**: The sender email address as string.
 
 **SES_REPLY_TO**: The reply to address
@@ -167,6 +170,7 @@ These are the available options:
 
     SES_AWS_ACCESS_KEY = ""
     SES_AWS_SECRET_KEY = ""
+    SES_REGION = ""
     SES_SENDER = ""
     SES_REPLY_TO = ""
     SES_TEMPLATE = None

--- a/ses_mailer.py
+++ b/ses_mailer.py
@@ -10,6 +10,7 @@ import os
 import re
 try:
     import boto
+    import boto.ses
 except ImportError as ex:
     print("Boto is missing. pip --install boto")
 try:
@@ -110,6 +111,7 @@ class Mail(object):
     def __init__(self,
                  aws_access_key_id=None,
                  aws_secret_access_key=None,
+                 region=None,
                  sender=None,
                  reply_to=None,
                  template=None,
@@ -123,8 +125,13 @@ class Mail(object):
             self.init_app(app)
         else:
             if aws_access_key_id and aws_secret_access_key:
-                self.ses = boto.connect_ses(aws_access_key_id=aws_access_key_id,
-                                            aws_secret_access_key=aws_secret_access_key)
+                if region:
+                    self.ses = boto.ses.connect_to_region(region,
+                                                          aws_access_key_id=aws_access_key_id,
+                                                          aws_secret_access_key=aws_secret_access_key)
+                else:
+                    self.ses = boto.connect_ses(aws_access_key_id=aws_access_key_id,
+                                                aws_secret_access_key=aws_secret_access_key)
 
             self.sender = sender
             self.reply_to = reply_to or self.sender
@@ -140,6 +147,7 @@ class Mail(object):
         """
         self.__init__(aws_access_key_id=app.config.get("SES_AWS_ACCESS_KEY"),
                       aws_secret_access_key=app.config.get("SES_AWS_SECRET_KEY"),
+                      region=app.config.get("SES_REGION", None),
                       sender=app.config.get("SES_SENDER", None),
                       reply_to=app.config.get("SES_REPLY_TO", None),
                       template=app.config.get("SES_TEMPLATE", None),

--- a/test_ses_mailer.py
+++ b/test_ses_mailer.py
@@ -6,6 +6,7 @@ Create a file test_config.py and add the following
 
 AWS_ACCESS_KEY_ID = ""
 AWS_SECRET_ACCESS_KEY = ""
+AWS_REGION = ""
 EMAIL_SENDER = ""
 EMAIL_RECIPIENT = ""
 
@@ -58,6 +59,7 @@ def test_template_render():
 
 mail = Mail(aws_secret_access_key=test_config.AWS_SECRET_ACCESS_KEY,
             aws_access_key_id=test_config.AWS_ACCESS_KEY_ID,
+            region=test_config.AWS_REGION,
             sender=test_config.EMAIL_SENDER,
             template=templateMap)
 


### PR DESCRIPTION
I had an issue trying trying to connect to an SES set up in the EU region. I've added an option to select the region using an ENV named SES_REGION. If the region is not provided it will just connect as before.  
