### PR TITLE
Fixed template_context handling for python3

### DIFF
--- a/ses_mailer.py
+++ b/ses_mailer.py
@@ -232,7 +232,7 @@ class Mail(object):
                          body=body,
                          reply_to=reply_to,
                          **mail_data)
-    
+
     def parse_template(self, template, **context):
         """
         To parse a template and return all the blocks
@@ -241,7 +241,7 @@ class Mail(object):
         optional_blocks = ["text_body", "html_body", "return_path", "format"]
 
         if self.template_context:
-            context = dict(self.template_context.items() + context.items())
+            context = dict(list(self.template_context.items()) + list(context.items()))
         blocks = self.template.render_blocks(template, **context)
 
         for rb in required_blocks:


### PR DESCRIPTION
In py3, dict.items() is not a list but a special dict_items object
which doesn't support `+` operator.

See second block of this answer:
http://stackoverflow.com/questions/38987/how-to-merge-two-python-dictionaries-in-a-single-expression#38990
